### PR TITLE
Fix date range filtering and event card date display

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -148,12 +148,40 @@ function keg_date_meta_for_range($from_ts, $to_ts){
     if(!$to_ts){ $to_ts = $from_ts; }
     if($to_ts < $from_ts){ $t=$from_ts; $from_ts=$to_ts; $to_ts=$t; }
 
-    $fromYmd = (int)date('Ymd',$from_ts);
-    $toYmd   = (int)date('Ymd',$to_ts);
+    $from_ts = (int)$from_ts;
+    $to_ts   = (int)$to_ts;
+    $range_end_ts = $to_ts + DAY_IN_SECONDS - 1; // include entire final day
+
+    $fromYmd = date('Ymd',$from_ts);
+    $toYmd   = date('Ymd',$to_ts);
+    $from_dt = date('Y-m-d 00:00:00',$from_ts);
+    $to_dt   = date('Y-m-d 23:59:59',$to_ts);
 
     $or = array('relation'=>'OR');
-    // Numeric Ymd range
-    $or[] = array('key'=>'event_date','value'=>array($fromYmd,$toYmd),'compare'=>'BETWEEN','type'=>'NUMERIC');
+
+    // Match ACF-style Ymd values stored as strings
+    $or[] = array(
+        'key'     => 'event_date',
+        'value'   => array($fromYmd,$toYmd),
+        'compare' => 'BETWEEN',
+        'type'    => 'CHAR',
+    );
+
+    // Match unix timestamps saved as numeric meta
+    $or[] = array(
+        'key'     => 'event_date',
+        'value'   => array($from_ts,$range_end_ts),
+        'compare' => 'BETWEEN',
+        'type'    => 'NUMERIC',
+    );
+
+    // Match The Events Calendar style datetime values
+    $or[] = array(
+        'key'     => '_EventStartDate',
+        'value'   => array($from_dt,$to_dt),
+        'compare' => 'BETWEEN',
+        'type'    => 'DATETIME',
+    );
 
     // Equality per day for common legacy string formats (cap 90 days)
     $max_days = 90;
@@ -168,9 +196,38 @@ function keg_date_meta_for_range($from_ts, $to_ts){
     return $or;
 }}
 
+/** Resolve a date range from preset + custom inputs. */
+if (!function_exists('keg_resolve_requested_date_range')){
+function keg_resolve_requested_date_range($preset, $from_input, $to_input){
+    $preset = trim(strtolower((string)$preset));
+
+    if(in_array($preset, array('today','tomorrow','weekend'), true)){
+        list($from_ts, $to_ts) = keg_date_preset_range($preset);
+        return array($from_ts, $to_ts);
+    }
+
+    $from_ts = $from_input ? keg_parse_to_ts($from_input) : null;
+    $to_ts   = $to_input ? keg_parse_to_ts($to_input) : null;
+
+    if($from_ts && $to_ts && $to_ts < $from_ts){
+        $tmp = $from_ts;
+        $from_ts = $to_ts;
+        $to_ts = $tmp;
+    }
+
+    if(!$from_ts && !$to_ts){
+        return array(null,null);
+    }
+
+    if(!$from_ts){ $from_ts = $to_ts; }
+    if(!$to_ts){   $to_ts   = $from_ts; }
+
+    return array($from_ts, $to_ts);
+}}
+
 /** Pretty string for card display. */
 if (!function_exists('keg_pretty_date_from_raw')){
 function keg_pretty_date_from_raw($raw){
     $ts = keg_parse_to_ts($raw);
-    return $ts ? date('D, M j Y',$ts) : '';
+    return $ts ? date_i18n('D, M j Y',$ts) : '';
 }}

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -116,6 +116,18 @@ function keg_render_results_count($ptype){
     if(!empty($_GET['event_city']))     $meta_query[]=['key'=>'event_city','value'=>sanitize_text_field($_GET['event_city']),'compare'=>'LIKE'];
     if(!empty($_GET['event_mode']))     $meta_query[]=['key'=>'event_mode','value'=>sanitize_text_field($_GET['event_mode']),'compare'=>'='];
 
+    $preset = isset($_GET['date_preset']) ? sanitize_text_field($_GET['date_preset']) : '';
+    $dfrom  = isset($_GET['date_from']) ? sanitize_text_field($_GET['date_from']) : '';
+    $dto    = isset($_GET['date_to']) ? sanitize_text_field($_GET['date_to']) : '';
+    $allowed_presets = array('','today','tomorrow','weekend','custom');
+    if(!in_array($preset,$allowed_presets,true)){ $preset=''; }
+
+    list($from_ts,$to_ts) = keg_resolve_requested_date_range($preset,$dfrom,$dto);
+    if($from_ts || $to_ts){
+        $date_clause = keg_date_meta_for_range($from_ts,$to_ts);
+        if(!empty($date_clause)){ $meta_query[] = $date_clause; }
+    }
+
     $args=['post_type'=>$ptype,'post_status'=>'publish','posts_per_page'=>1,'fields'=>'ids','no_found_rows'=>false,'meta_query'=>$meta_query];
     $q=new WP_Query($args);
     $total = intval($q->found_posts);
@@ -132,6 +144,12 @@ function keg_events_loop_html($args=[]){
 
     $meta_query=['relation'=>'AND'];
     $tax_query=[];
+
+    $preset = isset($_GET['date_preset']) ? sanitize_text_field($_GET['date_preset']) : '';
+    $dfrom  = isset($_GET['date_from']) ? sanitize_text_field($_GET['date_from']) : '';
+    $dto    = isset($_GET['date_to']) ? sanitize_text_field($_GET['date_to']) : '';
+    $allowed_presets = array('','today','tomorrow','weekend','custom');
+    if(!in_array($preset,$allowed_presets,true)){ $preset=''; }
 
     if($keyword){
         $meta_query[]=['relation'=>'OR',
@@ -153,19 +171,10 @@ function keg_events_loop_html($args=[]){
         $meta_query[]=['key'=>'event_mode','value'=>$val,'compare'=>'='];
     }
 
-    // date logic
-    $from_ts = null; $to_ts=null;
-    if(in_array($preset, array('today','tomorrow','weekend'), true)){
-        list($from_ts,$to_ts)=keg_date_preset_range($preset);
-        if($from_ts){
-            $meta_query[] = keg_build_date_or($from_ts, $to_ts);
-        }
-    } else {
-        $from_ts = $dfrom ? strtotime($dfrom.' 00:00:00') : null;
-        $to_ts   = $dto   ? strtotime($dto.' 23:59:59') : null;
-        if($from_ts || $to_ts){
-            $meta_query[] = keg_build_date_or($from_ts ?: strtotime('today 00:00:00'), $to_ts ?: $from_ts);
-        }
+    list($from_ts,$to_ts) = keg_resolve_requested_date_range($preset,$dfrom,$dto);
+    if($from_ts || $to_ts){
+        $date_clause = keg_date_meta_for_range($from_ts,$to_ts);
+        if(!empty($date_clause)){ $meta_query[] = $date_clause; }
     }
 
     $query_args=[

--- a/templates/card.php
+++ b/templates/card.php
@@ -3,17 +3,22 @@ $ename = function_exists('get_field') ? get_field('event_name') : '';
 $ecity = function_exists('get_field') ? get_field('event_city') : '';
 $ecat  = function_exists('get_field') ? get_field('event_category') : '';
 $edate = function_exists('get_field') ? get_field('event_date') : '';
+if($edate === '' || $edate === null){
+    $edate = get_post_meta(get_the_ID(),'event_date',true);
+}
 $emode = function_exists('get_field') ? get_field('event_mode') : '';
 $venue = function_exists('get_field') ? get_field('event_venue') : '';
 $addr  = function_exists('get_field') ? get_field('event_address') : '';
 
 $display_date = '';
 if ($edate) {
-    if (is_numeric($edate))      $display_date = date_i18n('D, M j Y', intval($edate));
-    elseif (strtotime($edate))   $display_date = date_i18n('D, M j Y', strtotime($edate));
-} else {
+    $display_date = keg_pretty_date_from_raw($edate);
+}
+if (!$display_date) {
     $tec = get_post_meta(get_the_ID(), '_EventStartDate', true);
-    if ($tec) $display_date = date_i18n('D, M j Y', strtotime($tec));
+    if ($tec) {
+        $display_date = keg_pretty_date_from_raw($tec);
+    }
 }
 $title = $ename ? $ename : get_the_title();
 ?>


### PR DESCRIPTION
## Summary
- normalize requested date ranges and build a unified meta query that works for timestamps, ACF Ymd strings, and TEC datetimes
- apply the corrected date filter logic to the results count and main events loop
- render card dates with the shared helper and fall back to post meta to prevent 1970-era placeholders

## Testing
- php -l includes/helpers.php
- php -l includes/shortcode.php
- php -l templates/card.php

------
https://chatgpt.com/codex/tasks/task_e_68d50e6bf350832099eb3764b6e03cb6